### PR TITLE
Fixed spelling mistake.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
             },
             {
                 "command": "sockscode.disconnect",
-                "title": "Sockscode disconect."
+                "title": "Sockscode disconnect."
             }
         ],
         "configuration": {


### PR DESCRIPTION
Changed "Sockscode disconect" for "Sockscode disconnect". Note the double n in disconnect.

PS: Very nice extension!